### PR TITLE
Chore: Refactor notification handling to use Firebase Cloud Messaging

### DIFF
--- a/utils/notificationTriggers.js
+++ b/utils/notificationTriggers.js
@@ -25,6 +25,10 @@ const triggerBlightRiskNotification = async (environmentalData) => {
     let title = `${riskLevel} Risk of ${blightType} Detected`;
     let message = "";
 
+    // Add a call-to-action for diagnostic confirmation
+    const diagnosticCTA =
+      "Take a photo of your plants now to confirm this assessment and get personalized recommendations.";
+
     if (blightType === "Early Blight") {
       message = `We've detected a ${riskLevel.toLowerCase()} risk of Early Blight in your area. Current CRI: ${environmentalData.cri.toFixed(
         1
@@ -33,13 +37,16 @@ const triggerBlightRiskNotification = async (environmentalData) => {
       // Add recommendations based on risk level
       if (riskLevel === "Medium") {
         message +=
-          "Consider monitoring your plants closely and applying preventive fungicides.";
+          "Consider monitoring your plants closely and applying preventive fungicides. " +
+          diagnosticCTA;
       } else if (riskLevel === "High") {
         message +=
-          "Immediate action recommended: Apply approved fungicides and inspect plants daily.";
+          "Immediate action recommended: Apply approved fungicides and inspect plants daily. " +
+          diagnosticCTA;
       } else if (riskLevel === "Critical") {
         message +=
-          "URGENT: Apply fungicides immediately and consider removing severely affected plants to prevent spread.";
+          "URGENT: Apply fungicides immediately and consider removing severely affected plants to prevent spread. " +
+          diagnosticCTA;
       }
     } else if (blightType === "Late Blight") {
       message = `We've detected a ${riskLevel.toLowerCase()} risk of Late Blight in your area. Current CRI: ${environmentalData.cri.toFixed(
@@ -49,17 +56,20 @@ const triggerBlightRiskNotification = async (environmentalData) => {
       // Add recommendations based on risk level
       if (riskLevel === "Medium") {
         message +=
-          "Begin preventive measures such as applying copper-based fungicides and avoiding overhead irrigation.";
+          "Begin preventive measures such as applying copper-based fungicides and avoiding overhead irrigation. " +
+          diagnosticCTA;
       } else if (riskLevel === "High") {
         message +=
-          "Apply protective fungicides immediately and reduce humidity around plants when possible.";
+          "Apply protective fungicides immediately and reduce humidity around plants when possible. " +
+          diagnosticCTA;
       } else if (riskLevel === "Critical") {
         message +=
-          "URGENT: Apply fungicides immediately, remove affected plants, and consider protective measures for remaining crops.";
+          "URGENT: Apply fungicides immediately, remove affected plants, and consider protective measures for remaining crops. " +
+          diagnosticCTA;
       }
     }
 
-    // Send the notification
+    // Send the notification with action data for deep linking
     await sendNotification(
       environmentalData.farmerId,
       title,
@@ -70,7 +80,9 @@ const triggerBlightRiskNotification = async (environmentalData) => {
         cri: environmentalData.cri,
         riskLevel: riskLevel,
         blightType: blightType,
-        date: environmentalData.date
+        date: environmentalData.date,
+        action: "diagnose", // Add action field for the frontend to use
+        url: "/diagnosis" // Add direct deep link to diagnosis page
       }
     );
   } catch (error) {


### PR DESCRIPTION
This pull request focuses on migrating the notification system from using Web Push API to Firebase Cloud Messaging (FCM) and includes several related improvements and refactorings. The most important changes are grouped by theme as follows:

### Migration to Firebase Cloud Messaging:

* [`controllers/notificationController.js`](diffhunk://#diff-11207b1d1c92e4e901ca363708b6d91755849899effbab3d0a12c504ffa00201R20-R41): Updated the `getVapidKey` function to return Firebase configuration instead of the VAPID public key.
* [`controllers/notificationController.js`](diffhunk://#diff-11207b1d1c92e4e901ca363708b6d91755849899effbab3d0a12c504ffa00201L153-R157): Simplified the `registerDevice` function to store the FCM token directly, removing the logic for handling Web Push subscriptions.

### Removal of Web Push API:

* [`utils/notificationService.js`](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5L5-L26): Removed the VAPID key configuration and the `sendWebPushNotification` function, as Web Push notifications are no longer used. [[1]](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5L5-L26) [[2]](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5L122-L200)

### Refactoring Notification Sending:

* [`utils/notificationService.js`](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5L209-L231): Updated the `sendPushNotification` function to send notifications using only FCM tokens and handle the removal of failed tokens. [[1]](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5L209-L231) [[2]](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5L244-R148) [[3]](diffhunk://#diff-77fe82f1d373fda1785d1c5872e110618d3aacef84bc47c77ace347bd60815d5R157-R162)

### Enhancements to Blight Risk Notifications:

* [`utils/notificationTriggers.js`](diffhunk://#diff-0c73e2c817cafe48f970e094a7df02a6ac95f193ac18c526f43e71ad3b124b2cR28-R31): Added a call-to-action for diagnostic confirmation and deep linking to the diagnosis page in blight risk notifications. [[1]](diffhunk://#diff-0c73e2c817cafe48f970e094a7df02a6ac95f193ac18c526f43e71ad3b124b2cR28-R31) [[2]](diffhunk://#diff-0c73e2c817cafe48f970e094a7df02a6ac95f193ac18c526f43e71ad3b124b2cL36-R49) [[3]](diffhunk://#diff-0c73e2c817cafe48f970e094a7df02a6ac95f193ac18c526f43e71ad3b124b2cL52-R72) [[4]](diffhunk://#diff-0c73e2c817cafe48f970e094a7df02a6ac95f193ac18c526f43e71ad3b124b2cL73-R85)