### PR TITLE
Fix: Correct CORS origin URL by removing trailing slash

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,10 +44,10 @@ app.use(
     origin: [
       "http://localhost:8080",
       "http://192.168.1.170:8080",
-      "https://tomato-expert-frontend.onrender.com/"
+      "https://tomato-expert-frontend.onrender.com"
     ],
     credentials: true,
-    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
   })
 );
 app.use(express.json({ limit: "10mb" }));


### PR DESCRIPTION
This pull request includes a minor update to the CORS configuration in the `server.js` file, addressing a formatting issue and improving consistency.

CORS configuration updates:

* Removed the trailing slash from the `https://tomato-expert-frontend.onrender.com` origin to ensure uniformity and prevent potential mismatches.
* Added a trailing comma to the `methods` array for better readability and consistency with modern JavaScript style guidelines.