### PR TITLE
Fix: Add VAPID public key to Firebase configuration response

### DIFF
--- a/controllers/notificationController.js
+++ b/controllers/notificationController.js
@@ -25,6 +25,7 @@ const getVapidKey = (req, res) => {
   try {
     // Return Firebase configuration for web
     res.status(200).json({
+      publicKey: process.env.VAPID_PUBLIC_KEY,
       firebaseConfig: {
         apiKey: process.env.FIREBASE_API_KEY,
         authDomain: process.env.FIREBASE_AUTH_DOMAIN,


### PR DESCRIPTION
This pull request includes a small change to the `controllers/notificationController.js` file. The change adds the `publicKey` field to the response of the `getVapidKey` function, using the `VAPID_PUBLIC_KEY` environment variable.